### PR TITLE
Fixes for autocomplete

### DIFF
--- a/FastColoredTextBox/AutocompleteMenu.cs
+++ b/FastColoredTextBox/AutocompleteMenu.cs
@@ -12,10 +12,9 @@ namespace FastColoredTextBoxNS
     /// Popup menu for autocomplete
     /// </summary>
     [Browsable(false)]
-    public class AutocompleteMenu : ToolStripDropDown
+    public class AutocompleteMenu : UserControl
     {
         AutocompleteListView listView;
-        public ToolStripControlHost host;
         public Range Fragment { get; internal set; }
 
         /// <summary>
@@ -70,20 +69,15 @@ namespace FastColoredTextBoxNS
         public AutocompleteMenu(FastColoredTextBox tb)
         {
             // create a new popup and add the list view to it 
-            AutoClose = false;
+            Visible = false;
+            BorderStyle = BorderStyle.FixedSingle;
             AutoSize = false;
             Margin = Padding.Empty;
             Padding = Padding.Empty;
             BackColor = Color.White;
             listView = new AutocompleteListView(tb);
-            host = new ToolStripControlHost(listView);
-            host.Margin = new Padding(2, 2, 2, 2);
-            host.Padding = Padding.Empty;
-            host.AutoSize = false;
-            host.AutoToolTip = false;
             CalcSize();
-            base.Items.Add(host);
-            listView.Parent = this;
+            this.Controls.Add(listView);
             SearchPattern = @"[\w\.]";
             MinFragmentLength = 2;
 
@@ -104,12 +98,11 @@ namespace FastColoredTextBoxNS
         public new void Close()
         {
             listView.toolTip.Hide(listView);
-            base.Close();
+            this.Hide();
         }
 
         internal void CalcSize()
         {
-            host.Size = listView.Size;
             Size = new System.Drawing.Size(listView.Size.Width + 4, listView.Size.Height + 4);
         }
 
@@ -376,8 +369,12 @@ namespace FastColoredTextBoxNS
                 {
                     CancelEventArgs args = new CancelEventArgs();
                     Menu.OnOpening(args);
-                    if(!args.Cancel)
-                        Menu.Show(tb, point);
+                    if (!args.Cancel)
+                    {
+                        Menu.Location = point;
+                        Menu.Parent = tb;
+                        Menu.Show();
+                    }
                 }
                 else
                     Invalidate();
@@ -678,8 +675,7 @@ namespace FastColoredTextBoxNS
                 return;
             }
 
-            var tbLocationOnScreen = tb.PointToScreen(Point.Empty);
-            var location = new Point(Right + 3 + Menu.Left - tbLocationOnScreen.X, Menu.Top - tbLocationOnScreen.Y);
+            var location = new Point(Right + 3 + Menu.Left, Menu.Top);
             if (string.IsNullOrEmpty(text))
             {
                 toolTip.ToolTipTitle = null;

--- a/FastColoredTextBox/AutocompleteMenu.cs
+++ b/FastColoredTextBox/AutocompleteMenu.cs
@@ -333,8 +333,8 @@ namespace FastColoredTextBoxNS
             FocussedItemIndex = 0;
             VerticalScroll.Value = 0;
             //some magic for update scrolls
-            AutoScrollMinSize -= new Size(1, 0);
             AutoScrollMinSize += new Size(1, 0);
+            AutoScrollMinSize -= new Size(1, 0);
             //get fragment around caret
             Range fragment = tb.Selection.GetFragment(Menu.SearchPattern);
             string text = fragment.Text;

--- a/FastColoredTextBox/AutocompleteMenu.cs
+++ b/FastColoredTextBox/AutocompleteMenu.cs
@@ -671,25 +671,30 @@ namespace FastColoredTextBoxNS
             var title = autocompleteItem.ToolTipTitle;
             var text = autocompleteItem.ToolTipText;
 
+            Control window = tb;
             if (string.IsNullOrEmpty(title))
             {
-                toolTip.ToolTipTitle = null;
-                toolTip.SetToolTip(this, null);
+                toolTip.Hide(window);
                 return;
             }
 
-            IWin32Window window = this.Parent ?? this;
-            Point location = new Point((window == this ? Width : Right) + 3, 0);
-
+            var tbLocationOnScreen = tb.PointToScreen(Point.Empty);
+            var location = new Point(Right + 3 + Menu.Left - tbLocationOnScreen.X, Menu.Top - tbLocationOnScreen.Y);
             if (string.IsNullOrEmpty(text))
             {
                 toolTip.ToolTipTitle = null;
-                toolTip.Show(title, window, location.X, location.Y, ToolTipDuration);
+                if (ToolTipDuration == 0)
+                    toolTip.Show(title, window, location);
+                else
+                    toolTip.Show(title, window, location, ToolTipDuration);
             }
             else
             {
                 toolTip.ToolTipTitle = title;
-                toolTip.Show(text, window, location.X, location.Y, ToolTipDuration);
+                if (ToolTipDuration == 0)
+                    toolTip.Show(text, window, location);
+                else
+                    toolTip.Show(text, window, location, ToolTipDuration);
             }
         }
 

--- a/FastColoredTextBox/AutocompleteMenu.cs
+++ b/FastColoredTextBox/AutocompleteMenu.cs
@@ -212,6 +212,11 @@ namespace FastColoredTextBoxNS
         internal int AppearInterval { get { return timer.Interval; } set { timer.Interval = value; } }
         internal int ToolTipDuration { get; set; }
 
+        public override Size GetPreferredSize(Size proposedSize)
+        {
+            return Size;
+        }
+
         public Color SelectedColor { get; set; }
         public Color HoveredColor { get; set; }
         public int FocussedItemIndex


### PR DESCRIPTION
Hi, I made some fixes that enable autocomplete popup work properly on Mono.

Issue 1 was that the popup was sized incorrectly and appeared as a thin vertical line 2x22 pixels in size. I found a thread by mono developers who discussed this issue and it turns out they decided to rely on PreferredSize for calculating size:
http://mono.1490590.n4.nabble.com/ToolStripDropDown-UserControl-td1542304.html
Thus I implemented GetPreferredSize override and this indeed helped.

Issue 2 was that sometimes my application would crash, stack trace pointing to something related to scroll. I tracked it down to DoAutocomplete method and noticed that AutoScrollMinSize -= new Size(1, 0); was called before AutoScrollMinSize += new Size(1, 0); which could lead to a negative value, so I changed places of those two and issue never happened again.

Issue 3 was that NullReferenceException would be thrown if tooltips are used in the autocomplete. Still not sure what exactly happens there, but by experiment I found out that changing window of the Tooltip to FastColoredTextBox instance fixes this.

Issue 4 was that once autocomplete popup appeared, it was no longer possible to type any text in the editor.

I explored Mono ToolStripDropDown implementation and found out that they disable keyboard capture of the application and enable it for the active ToolStrip, see SetActiveToolStrip method in ToolStripManager class: https://github.com/mono/mono/blob/master/mcs/class/System.Windows.Forms/System.Windows.Forms/ToolStripManager.cs

I tried different methods of returning the focus and keyboard capture back to the textbox control, but haven't found a working solution. By that time I already knew AutocompleteMenu and AutocompleteListView implementations really well and actually I started wondering, why the ToolStripDropDown is even needed? These classes are pretty much independent in fact, and even manually drawn... So I cut off the ToolStripDropDown altogether, instead deriving AutocompleteMenu from UserControl. It was actually a painless operation, as I already mentioned, there haven't been any real dependencies. And after that, autocomplete works really fine on Mono which I'm extremely happy about :)

Best,
Andrei